### PR TITLE
Re-using everest_aes_gcm_args when calling mbedtls_everest_prepare_ae…

### DIFF
--- a/3rdparty/everest/library/everest.c
+++ b/3rdparty/everest/library/everest.c
@@ -229,7 +229,14 @@ void mbedtls_everest_prepare_aes_gcm_buffer(
         }
     }
     else
+    {
+        if (*argbuf_size)
+        {
+                mbedtls_free(*argbuf);
+                *argbuf = NULL;
+        }
         *argbuf_size = 0;
+    }
 }
 
 void mbedtls_everest_prepare_aes_gcm_buffers(


### PR DESCRIPTION
## Description
Re-using everest_aes_gcm_args when calling mbedtls_everest_prepare_aes_gcm_buffer could cause a leak:

1. mbedtls_everest_prepare_aes_gcm_buffer is called to allocate a buffer (inbuf_size > 0)
2. argbuf now points to a newly allocated buffer, while argbuf_size points to the new buffer's size
3. mbedtls_everest_prepare_aes_gcm_buffer is called with inbuf_size == 0
4. argbuf_size points to 0 (the new size), but whenever there is a check on whether argbuf should be freed (on mbedtls_everest_prepare_aes_gcm_buffer and mbedtls_everest_aes_gcm_free), it only checks whether argbuf_size > 0

## Status
READY